### PR TITLE
Implement caching of global ID result of latest schema call

### DIFF
--- a/src/avrocurio/apicurio_client.py
+++ b/src/avrocurio/apicurio_client.py
@@ -63,6 +63,12 @@ class ApicurioClient:
         )
         self._failed_lookup_cache_lock = asyncio.Lock()
 
+        self._artifact_id_to_global_id_cache = TTLCache(
+            maxsize=config.latest_schema_cache_size,
+            ttl=config.latest_schema_cache_ttl,
+        )
+        self._artifact_id_to_global_id_cache_lock = asyncio.Lock()
+
     async def __aenter__(self) -> Self:
         """Async context manager entry."""
         return self
@@ -81,6 +87,7 @@ class ApicurioClient:
         await self._client.aclose()
         self._schema_cache.clear()
         self._failed_lookup_cache.clear()
+        self._artifact_id_to_global_id_cache.clear()
 
     async def _raise_if_previous_lookup_failed(self, global_id: int) -> None:
         """Check failed lookup cache and raise if found."""
@@ -154,7 +161,7 @@ class ApicurioClient:
 
     async def get_latest_schema(self, group_id: str, artifact_id: str) -> tuple[int, dict[str, Any]]:
         """
-        Get the latest version of a schema by group and artifact ID with LRU caching.
+        Get the latest version of a schema by group and artifact ID with TTL caching.
 
         Args:
             group_id: Group ID containing the artifact
@@ -168,9 +175,8 @@ class ApicurioClient:
             AvroCurioError: For other API errors
 
         """
-        cache_key = (group_id, artifact_id)
-        async with self._schema_cache_lock:
-            cached_global_id = self._schema_cache.get(cache_key)
+        async with self._artifact_id_to_global_id_cache_lock:
+            cached_global_id = self._artifact_id_to_global_id_cache.get((group_id, artifact_id))
         if cached_global_id is not None:
             schema = await self.get_schema_by_global_id(cached_global_id)
             return cached_global_id, schema
@@ -205,8 +211,8 @@ class ApicurioClient:
         # Now fetch the actual schema content
         schema = await self.get_schema_by_global_id(global_id)
 
-        async with self._schema_cache_lock:
-            self._schema_cache[cache_key] = global_id
+        async with self._artifact_id_to_global_id_cache_lock:
+            self._artifact_id_to_global_id_cache[(group_id, artifact_id)] = global_id
         return global_id, schema
 
     async def search_artifacts(self, name: str | None = None, artifact_type: str = "AVRO") -> list[dict[str, Any]]:
@@ -417,6 +423,8 @@ class ApicurioClient:
             self._schema_cache.clear()
         async with self._failed_lookup_cache_lock:
             self._failed_lookup_cache.clear()
+        async with self._artifact_id_to_global_id_cache_lock:
+            self._artifact_id_to_global_id_cache.clear()
 
     async def get_cache_stats(self) -> dict[str, Any]:
         """
@@ -435,10 +443,18 @@ class ApicurioClient:
             failed_max_size = self._failed_lookup_cache.maxsize
             failed_ttl = self._failed_lookup_cache.ttl
 
+        async with self._artifact_id_to_global_id_cache_lock:
+            latest_size = len(self._artifact_id_to_global_id_cache)
+            latest_max_size = self._artifact_id_to_global_id_cache.maxsize
+            latest_ttl = self._artifact_id_to_global_id_cache.ttl
+
         return {
             "schema_cache_size": schema_size,
             "schema_cache_max_size": schema_max_size,
             "failed_lookup_cache_size": failed_size,
             "failed_lookup_cache_max_size": failed_max_size,
             "failed_lookup_cache_ttl": failed_ttl,
+            "latest_schema_cache_size": latest_size,
+            "latest_schema_cache_max_size": latest_max_size,
+            "latest_schema_cache_ttl": latest_ttl,
         }

--- a/src/avrocurio/apicurio_client.py
+++ b/src/avrocurio/apicurio_client.py
@@ -154,7 +154,7 @@ class ApicurioClient:
 
     async def get_latest_schema(self, group_id: str, artifact_id: str) -> tuple[int, dict[str, Any]]:
         """
-        Get the latest version of a schema by group and artifact ID.
+        Get the latest version of a schema by group and artifact ID with LRU caching.
 
         Args:
             group_id: Group ID containing the artifact
@@ -168,6 +168,13 @@ class ApicurioClient:
             AvroCurioError: For other API errors
 
         """
+        cache_key = (group_id, artifact_id)
+        async with self._schema_cache_lock:
+            cached_global_id = self._schema_cache.get(cache_key)
+        if cached_global_id is not None:
+            schema = await self.get_schema_by_global_id(cached_global_id)
+            return cached_global_id, schema
+
         try:
             # First get the artifact metadata to find the latest version
             url = f"/apis/registry/v3/groups/{group_id}/artifacts/{artifact_id}/versions/branch=latest"
@@ -197,6 +204,9 @@ class ApicurioClient:
 
         # Now fetch the actual schema content
         schema = await self.get_schema_by_global_id(global_id)
+
+        async with self._schema_cache_lock:
+            self._schema_cache[cache_key] = global_id
         return global_id, schema
 
     async def search_artifacts(self, name: str | None = None, artifact_type: str = "AVRO") -> list[dict[str, Any]]:

--- a/src/avrocurio/config.py
+++ b/src/avrocurio/config.py
@@ -16,6 +16,8 @@ class ApicurioConfig:
         schema_cache_size: Maximum number of schemas to cache (0 disables caching)
         failed_lookup_cache_size: Maximum number of failed lookups to cache (0 disables caching)
         failed_lookup_cache_ttl: TTL in seconds for failed lookup cache entries
+        latest_schema_cache_size: Maximum number of artifact→global_id mappings to cache
+        latest_schema_cache_ttl: TTL in seconds for artifact→global_id cache entries
 
     """
 
@@ -26,3 +28,5 @@ class ApicurioConfig:
     schema_cache_size: int = 1000
     failed_lookup_cache_size: int = 100
     failed_lookup_cache_ttl: int = 300
+    latest_schema_cache_size: int = 1000
+    latest_schema_cache_ttl: int = 600

--- a/tests/test_schema_client.py
+++ b/tests/test_schema_client.py
@@ -201,7 +201,7 @@ class TestApicurioClient:
         schema_id = 12345
 
         # Pre-populate both the artifact→global_id mapping and the schema itself
-        client._schema_cache[("default", "user-schema")] = schema_id
+        client._artifact_id_to_global_id_cache[("default", "user-schema")] = schema_id
         client._schema_cache[schema_id] = sample_schema
 
         mock_client = AsyncMock()
@@ -214,21 +214,31 @@ class TestApicurioClient:
         client._client.get.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_get_latest_schema_cache_key_isolation(self, config, sample_schema):
-        """Test that a cache hit for one artifact does not affect a different one."""
+    async def test_get_latest_schema_cache_key_isolation(self, config, sample_schema, mock_success_response):
+        """Test that a cache hit for one artifact does not cause a hit for a different one."""
         client = ApicurioClient(config)
 
         # Only pre-populate "group-a/schema"; leave "group-b/schema" uncached
-        client._schema_cache[("group-a", "schema")] = 1
+        client._artifact_id_to_global_id_cache[("group-a", "schema")] = 1
         client._schema_cache[1] = sample_schema
 
+        # group-b requires two network calls: metadata + schema content
         mock_client = AsyncMock()
+        mock_client.get.side_effect = [
+            mock_success_response({"globalId": 2}, is_json=True),
+            mock_success_response(sample_schema, is_json=False),
+        ]
         client._client = mock_client
 
-        # group-a hit: no HTTP calls
-        schema, _ = await client.get_latest_schema("group-a", "schema")
-        assert schema == 1
-        client._client.get.assert_not_called()
+        # group-a is cached: no HTTP calls
+        gid_a, _ = await client.get_latest_schema("group-a", "schema")
+        assert gid_a == 1
+        mock_client.get.assert_not_called()
+
+        # group-b is not cached: must hit the network
+        gid_b, _ = await client.get_latest_schema("group-b", "schema")
+        assert gid_b == 2
+        assert mock_client.get.call_count == 2
 
     @pytest.mark.asyncio
     async def test_search_artifacts_success(self, config):

--- a/tests/test_schema_client.py
+++ b/tests/test_schema_client.py
@@ -195,6 +195,42 @@ class TestApicurioClient:
             await client.get_latest_schema("default", "user-schema")
 
     @pytest.mark.asyncio
+    async def test_get_latest_schema_cached(self, config, sample_schema):
+        """Test cached latest schema retrieval skips the network."""
+        client = ApicurioClient(config)
+        schema_id = 12345
+
+        # Pre-populate both the artifact→global_id mapping and the schema itself
+        client._schema_cache[("default", "user-schema")] = schema_id
+        client._schema_cache[schema_id] = sample_schema
+
+        mock_client = AsyncMock()
+        client._client = mock_client
+
+        global_id, schema = await client.get_latest_schema("default", "user-schema")
+
+        assert global_id == schema_id
+        assert schema == sample_schema
+        client._client.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_get_latest_schema_cache_key_isolation(self, config, sample_schema):
+        """Test that a cache hit for one artifact does not affect a different one."""
+        client = ApicurioClient(config)
+
+        # Only pre-populate "group-a/schema"; leave "group-b/schema" uncached
+        client._schema_cache[("group-a", "schema")] = 1
+        client._schema_cache[1] = sample_schema
+
+        mock_client = AsyncMock()
+        client._client = mock_client
+
+        # group-a hit: no HTTP calls
+        schema, _ = await client.get_latest_schema("group-a", "schema")
+        assert schema == 1
+        client._client.get.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_search_artifacts_success(self, config):
         """Test successful artifact search."""
         client = ApicurioClient(config)


### PR DESCRIPTION
Currently only the calls to get schema by global ID is cached which is fine for deserialization.
However, calls to fetch the latest schema doesn't cache the global ID returned which means serialization will fail if Apicurio is down at the time.

This change introduces caching of the global ID returned by `get_latest_schema` using the same TTL.
Clearing of cache is already available as an existing function, `clear_cache` which if needed consumers can use if they require that the latest version is always fetched.